### PR TITLE
[FIX](tmLanguage): fixing regex for form_for

### DIFF
--- a/syntaxes/plush.tmLanguage.json
+++ b/syntaxes/plush.tmLanguage.json
@@ -96,7 +96,7 @@
         "keyword": {
             "patterns": [
                 {
-                    "match": "(?i)(\bfunction\b|\blet\b|\bif\b|\belse\b|\breturn\b|\bfor\b|\bin\b|\bfn\b|\bfunc\b)",
+                    "match": "(?i)\\b(function|let|if|else|return|for|in|fn|func|form_for|form)\\b",
                     "name": "keyword.plush"
                 },
                 {
@@ -153,7 +153,7 @@
                     "name": "constant.numeric.plush"
                 },
                 {
-                    "match": "[a-zA-Z]+(\\()",
+                    "match": "[A-Za-z0-9_-]+(\\()",
                     "captures": {
                         "0": {
                             "name": "entity.name.function.plush"
@@ -164,7 +164,7 @@
                     }
                 },
                 {
-                    "match": "\b[a-zA-z]\b",
+                    "match": "\b[A-Za-z0-9_-]\b",
                     "name": "variable.name.plush"
                 }
             ]


### PR DESCRIPTION
### What is being done in this PR?
> Added some tweaks for the regular expressions we use to capture keywords, variable names and function names 

### What are the main choices made to get to this solution?
> Included the escaping of dashes and underscores. This way we can set variable name like **example_variable** and the extension will recognize this as a variable or name function.

### List the manual test cases you've covered before sending this PR:
> Example:
> - GIVEN the user types the form_for() statement  THEN the extension highlights the hole name and set it as a Plush Keyword ✅
